### PR TITLE
Fix issues with Rank members by (rounded) hours used query

### DIFF
--- a/questions/aggregates/00100000-rankmembers.ex
+++ b/questions/aggregates/00100000-rankmembers.ex
@@ -20,9 +20,9 @@ order by rank, surname, firstname;
 <p>Talking of clarity, this rounding malarky is starting to introduce a noticeable amount of code repetition.  At this point it's a judgement call, but you may wish to factor it out using a subquery as below:</p>
 
 <sql>
-select firstname, surname, hours, rank() over (order by hours) from
+select firstname, surname, hours, rank() over (order by hours desc) rank from
 	(select firstname, surname,
-		((sum(bks.slots)+5)/20)*10 as hours
+		((sum(bks.slots)+10)/20)*10 as hours
 
 		from cd.bookings bks
 		inner join cd.members mems


### PR DESCRIPTION
the subquery example should add 10 and order by hours desc